### PR TITLE
remove redundant sqlconfig

### DIFF
--- a/options/config.go
+++ b/options/config.go
@@ -22,15 +22,6 @@ type Config struct {
 	KafkaConsumer   consumer.Config
 }
 
-type SQLDBConfig struct {
-	Host         string
-	Port         int
-	User         string
-	Pass         string
-	DBName       string
-	MaxOpenConns int
-}
-
 type KafkaTopic struct {
 	Hello string
 }


### PR DESCRIPTION
Since `postgres.Config` is used in `options.Config` `options.SQLDBConfig` became redundant